### PR TITLE
[giyeon] 앞자리 배정 학생 지정 기능 추가

### DIFF
--- a/src/components/students/FrontSeatStudents.jsx
+++ b/src/components/students/FrontSeatStudents.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+import { useStudents } from "../../contexts/StudentContext";
+
+import StudentsName from "./StudentsName";
+
+const FrontSeatStudents = () => {
+  const studentsList = useStudents().data.filter((student) => student.isFront);
+
+  return (
+    <div className="bg-blue-200 p-2 mt-3">
+      <p className="text-sm font-bold mb-1 p-2">앞 2줄에 앉을 학생 지정</p>
+      <div
+        className={`rounded-xl border border-gray-400 p-2 ${
+          studentsList.length === 0 ? "h-16" : "h-auto"
+        }`}
+      >
+        {studentsList.map((student) => (
+          <StudentsName student={student} key={student.id} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default FrontSeatStudents;

--- a/src/components/students/Students.jsx
+++ b/src/components/students/Students.jsx
@@ -1,0 +1,17 @@
+import { StudentProvider } from "../../contexts/StudentContext";
+import CardLayout from "../../layouts/CardLayout";
+import StudentsList from "./StudentsList";
+import FrontSeatStudents from "./FrontSeatStudents";
+
+const Students = () => {
+  return (
+    <StudentProvider>
+      <CardLayout title={"학생 설정"}>
+        <StudentsList />
+        <FrontSeatStudents />
+      </CardLayout>
+    </StudentProvider>
+  );
+};
+
+export default Students;

--- a/src/components/students/StudentsList.jsx
+++ b/src/components/students/StudentsList.jsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { useStudents } from "../../contexts/StudentContext";
+import StudentsName from "./StudentsName";
+
+const StudentsList = () => {
+  const studentsList = useStudents().data;
+
+  return (
+    <div className="border border-blue-200 p-2">
+      <p className="text-center text-sky-600 text-sm font-bold mb-1">이름</p>
+      {studentsList.map((student) => (
+        <StudentsName student={student} key={student.id} />
+      ))}
+    </div>
+  );
+};
+
+export default StudentsList;

--- a/src/components/students/StudentsName.jsx
+++ b/src/components/students/StudentsName.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { useStudentsDispatch } from "../../contexts/StudentContext";
+
+const StudentsName = ({ student }) => {
+  const dispatch = useStudentsDispatch();
+
+  const handleClick = () => {
+    dispatch({ type: "TOGGLE_ISFRONT", id: student.id });
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      key={student.id}
+      className={`p-1 m-0.5 bg-white rounded-full shadow-md text-center leading-loose cursor-pointer border ${
+        student.isFront ? "border-sky-600" : "border-gray-200"
+      }`}
+    >
+      {student.name}
+    </button>
+  );
+};
+
+export default StudentsName;

--- a/src/contexts/StudentContext.jsx
+++ b/src/contexts/StudentContext.jsx
@@ -1,0 +1,84 @@
+import { createContext, useContext, useReducer } from "react";
+
+// 더미 학생 데이터
+const dummyStudents = [
+  { id: 0, name: "강상택", isFront: false },
+  { id: 1, name: "권정주", isFront: false },
+  { id: 2, name: "김민영", isFront: false },
+  { id: 3, name: "김성은", isFront: false },
+  { id: 4, name: "김영재", isFront: false },
+  { id: 5, name: "김윤미", isFront: false },
+  { id: 6, name: "김윤서", isFront: false },
+  { id: 7, name: "김종민", isFront: false },
+  { id: 8, name: "김현진", isFront: false },
+  { id: 9, name: "김효민", isFront: false },
+  { id: 10, name: "남기연", isFront: true },
+  { id: 11, name: "문원규", isFront: true },
+  { id: 12, name: "민택기", isFront: true },
+  { id: 13, name: "박민서", isFront: true },
+  { id: 14, name: "박준상", isFront: true },
+  { id: 15, name: "배준혁", isFront: false },
+  { id: 16, name: "배효정", isFront: false },
+  { id: 17, name: "사혜빈", isFront: false },
+  { id: 18, name: "신경남", isFront: false },
+  { id: 19, name: "신수연", isFront: false },
+  { id: 20, name: "양유진", isFront: false },
+  { id: 21, name: "양은서", isFront: false },
+  { id: 22, name: "양채연", isFront: false },
+  { id: 23, name: "양현정", isFront: false },
+  { id: 24, name: "오지영", isFront: false },
+  { id: 25, name: "이영은", isFront: false },
+  { id: 26, name: "이의섭", isFront: false },
+  { id: 27, name: "이정복", isFront: false },
+  { id: 28, name: "이제용", isFront: false },
+  { id: 29, name: "이종혁", isFront: false },
+  { id: 30, name: "임건애", isFront: false },
+  { id: 31, name: "정용준", isFront: false },
+  { id: 32, name: "조원희", isFront: false },
+  { id: 33, name: "주민경", isFront: false },
+  { id: 34, name: "박소희", isFront: false },
+];
+
+// 학생 데이터를 제공하는 컨텍스트
+export const StudentContext = createContext();
+export const StudentDispatchContext = createContext();
+
+export const StudentProvider = ({ children }) => {
+  const [studentsList, dispatch] = useReducer(reducer, { data: dummyStudents });
+
+  return (
+    <StudentContext.Provider value={studentsList}>
+      <StudentDispatchContext.Provider value={dispatch}>
+        {children}
+      </StudentDispatchContext.Provider>
+    </StudentContext.Provider>
+  );
+};
+
+export const useStudents = () => useContext(StudentContext);
+export const useStudentsDispatch = () => useContext(StudentDispatchContext);
+
+const reducer = (students, action) => {
+  const { data } = students;
+
+  switch (action.type) {
+    case "ADD_STUDENT": {
+      const { newStudent } = action;
+      return { data: [...data, newStudent] };
+    }
+
+    case "REMOVE_STUDENT": {
+      const { id } = action;
+      const removedStuents = data.filter((student) => student.id !== id);
+      return { data: removedStuents };
+    }
+
+    case "TOGGLE_ISFRONT": {
+      const { id } = action;
+      const toggledStudents = data.map((student) =>
+        student.id === id ? { ...student, isFront: !student.isFront } : student
+      );
+      return { data: toggledStudents };
+    }
+  }
+};


### PR DESCRIPTION
## 구현 기능
> 추가하려는 기능에 대해 간결하게 설명해주세요

- 앞 두줄에 배정할 학생을 클릭으로 지정하고, 취소할 수 있는 기능을 구현했습니다.

<br>

## 작업 상세 내용

<img width="997" height="561" alt="image" src="https://github.com/user-attachments/assets/3947d6b7-daba-4dae-904f-8fae721dac5f" />

- [x] 학생 리스트 Context API로 관리
- [x] 학생 리스트를 변경하는 로직을 useReducer로 관리
- [x] 자리 배정할 학생 리스트 렌더링
- [x] 앞자리로 배정될 학생 이름에 파란색 테두리 추가
- [x] 학생 이름 클릭으로 앞자리 배정/취소 
<br>
      
## 참고할만한 내용(선택)
